### PR TITLE
Potential fix for code scanning alert no. 644: Shell command built from environment values

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,6 +1,8 @@
 # GoSec Security Checker
 # This workflow runs gosec to check Go code for security issues
 name: GoSec Security Checker
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,6 +1,8 @@
 # Markdown Lint
 # This workflow runs markdownlint on all Markdown files in the repository
 name: Markdown Lint
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,6 +1,8 @@
 # GitHub Metrics
 # This workflow generates a metrics SVG and commits it to the repository
 name: Metrics Embed
+permissions:
+  contents: write
 
 on:
   schedule: [{cron: "0 0 * * 0"}] # every week

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Pylint
 
 on: [push]

--- a/.github/workflows/python-docs.yml
+++ b/.github/workflows/python-docs.yml
@@ -1,6 +1,8 @@
 # Python Auto Documentation
 # This workflow auto-generates documentation using Sphinx
 name: Python Auto Documentation
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/python-style.yml
+++ b/.github/workflows/python-style.yml
@@ -1,6 +1,8 @@
 # Python Style Check
 # This workflow checks Python code style using flake8
 name: Python Style Check
+permissions:
+  contents: read
 
 on:
   push:

--- a/build/azure-pipelines/publish-types/update-types.ts
+++ b/build/azure-pipelines/publish-types/update-types.ts
@@ -16,7 +16,7 @@ try {
 
 	const dtsUri = `https://raw.githubusercontent.com/microsoft/vscode/${tag}/src/vscode-dts/vscode.d.ts`;
 	const outPath = path.resolve(process.cwd(), 'DefinitelyTyped/types/vscode/index.d.ts');
-	cp.execSync(`curl ${dtsUri} --output ${outPath}`);
+	cp.execFileSync('curl', [dtsUri, '--output', outPath]);
 
 	updateDTSFile(outPath, tag);
 


### PR DESCRIPTION
Potential fix for [https://github.com/SoftwareDevLabs/SDLC_core/security/code-scanning/644](https://github.com/SoftwareDevLabs/SDLC_core/security/code-scanning/644)

To fix the problem, we should avoid constructing the shell command as a single string and passing it to `execSync`, which invokes a shell and is vulnerable to misinterpretation of arguments. Instead, we should use `execFileSync`, which allows us to pass the command and its arguments as separate elements in an array, ensuring that each argument is interpreted literally and not subject to shell expansion or splitting. Specifically, in `build/azure-pipelines/publish-types/update-types.ts`, replace the use of `cp.execSync` on line 19 with `cp.execFileSync`, passing `"curl"` as the command and `["dtsUri", "--output", "outPath"]` as the arguments array. No additional imports are needed, as `child_process` is already imported as `cp`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
